### PR TITLE
Fix start_client monkey patch

### DIFF
--- a/src/SSHLibrary/pythonclient.py
+++ b/src/SSHLibrary/pythonclient.py
@@ -28,13 +28,14 @@ from .abstractclient import (AbstractShell, AbstractSFTPClient,
 
 
 # There doesn't seem to be a simpler way to increase banner timeout
-def _custom_start_client(self, event=None):
+def _custom_start_client(self, *arg, **kwargs):
     self.banner_timeout = 45
-    self._orig_start_client(event)
+    self._orig_start_client(*arg, **kwargs)
 
 paramiko.transport.Transport._orig_start_client = \
     paramiko.transport.Transport.start_client
 paramiko.transport.Transport.start_client = _custom_start_client
+
 
 # See http://code.google.com/p/robotframework-sshlibrary/issues/detail?id=55
 def _custom_log(self, level, msg, *args):
@@ -169,6 +170,7 @@ class SFTPClient(AbstractSFTPClient):
 
     def _is_windows_path(self, path):
         return bool(ntpath.splitdrive(path)[0])
+
 
 class RemoteCommand(AbstractCommand):
 


### PR DESCRIPTION
Credit to @raphaelcastaneda and @terokinnunen in pull request #159.

Make changes for paramiko 2.1 argument in start_client, while being backwards compatible.

This is the suggested changes from #159. There have been several days since the review and no progress, so I made it here. I checked back to the [Dev commits](https://github.com/paramiko/paramiko/blob/01bf5477a04cbb34974aae92f6c5965572800b63/paramiko/transport.py) of paramiko and the default of event=None in start_client is there. Release 1.8+ (minimum required defined by this package) definitely has it so I removed everything from the monkey patch that wasn't changing the banner timeout as that was the only desired change. 

Also made whitespace changes.