### PR TITLE
Replaces hardcoded 'localhost' by ${HOST}.

### DIFF
--- a/atest/get_connection.txt
+++ b/atest/get_connection.txt
@@ -36,8 +36,8 @@ Get Connection Index Only
 
 Get Connection Host And Timeout Only
     Open Connection  ${HOST}  timeout=3 seconds
-    ${host}  ${timeout}=  Get Connection  host=Yes  timeout=True  port=false
-    Should Be Equal  ${host}  ${HOST}
+    ${rhost}  ${timeout}=  Get Connection  host=Yes  timeout=True  port=false
+    Should Be Equal  ${rhost}  ${HOST}
     Should Be Equal As Integers  ${timeout}  3
 
 Get Connections

--- a/atest/get_connection.txt
+++ b/atest/get_connection.txt
@@ -37,7 +37,7 @@ Get Connection Index Only
 Get Connection Host And Timeout Only
     Open Connection  ${HOST}  timeout=3 seconds
     ${host}  ${timeout}=  Get Connection  host=Yes  timeout=True  port=false
-    Should Be Equal  ${host}  localhost
+    Should Be Equal  ${host}  ${HOST}
     Should Be Equal As Integers  ${timeout}  3
 
 Get Connections


### PR DESCRIPTION
This allows atest to be run also on remote server.