### PR TITLE
Python 3 compatibility changes (#152 cleaned up)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ build
 dist
 .DS_Store
 .idea
+*.iml
 *.pyc
 *.class
 *.egg-info

--- a/atest/put_file.robot
+++ b/atest/put_file.robot
@@ -65,7 +65,9 @@ Put File And Specify Remote Newlines
     ${expected} =  OS.Get Binary File  ${FILE WITH NEWLINES}
     SSH.Get File  ${target}  ${LOCAL TMPDIR}${/}
     ${content} =  OS.Get Binary File  ${LOCAL TMPDIR}${/}${FILE WITH NEWLINES NAME}
-    ${content}=  Replace String  ${content}  \r\n  ${\n}
+    ${crlf}=  Encode String To Bytes  \r\n  UTF-8
+    ${\n}=  Encode String To Bytes  ${\n}  UTF-8
+    ${content}=  Replace String  ${content}  ${crlf}  ${\n}
     Should Be Equal  ${content}  ${expected}
     [Teardown]  Remove Local Temp Dir And Remote File  ${target}
 

--- a/atest/run.py
+++ b/atest/run.py
@@ -67,5 +67,5 @@ if __name__ == '__main__':
         rc = 251
     else:
         rc = atests(*sys.argv[1:])
-    print "\nAfter status check there were %s failures." % rc
+    print("\nAfter status check there were %s failures." % rc)
     sys.exit(rc)

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-from __future__ import with_statement
 from sys import platform
 
 requires = {}
@@ -19,7 +18,7 @@ except ImportError:
 from os.path import abspath, dirname, join
 
 CURDIR = dirname(abspath(__file__))
-execfile(join(CURDIR, 'src', 'SSHLibrary', 'version.py'))
+exec(compile(open(join(CURDIR, 'src', 'SSHLibrary', 'version.py')).read(), 'version.py', 'exec'))
 with open(join(CURDIR, 'README.rst')) as readme:
     README = readme.read()
 CLASSIFIERS = """

--- a/src/SSHLibrary/abstractclient.py
+++ b/src/SSHLibrary/abstractclient.py
@@ -12,7 +12,9 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from __future__ import with_statement
+
+from robot.utils import is_integer, is_string, unic
+
 from fnmatch import fnmatchcase
 
 import os
@@ -150,10 +152,12 @@ class AbstractSSHClient(object):
         return self._read_login_output(delay)
 
     def _encode(self, text):
-        if isinstance(text, str):
+        if is_string(text):
             return text
-        if not isinstance(text, basestring):
-            text = unicode(text)
+        if is_integer(text):
+            return "%d" % text
+        if not is_string(text):
+            text = str(text)
         return text.encode(self.config.encoding)
 
     def _login(self, username, password, look_for_keys=False):
@@ -304,7 +308,7 @@ class AbstractSSHClient(object):
     def _delayed_read(self, delay):
         delay = TimeEntry(delay).value
         max_time = time.time() + self.config.get('timeout').value
-        output = ''
+        output = bytes()
         while time.time() < max_time:
             time.sleep(delay)
             read = self.shell.read()
@@ -321,7 +325,7 @@ class AbstractSSHClient(object):
 
         :returns: A single char read from the output.
         """
-        server_output = ''
+        server_output = bytes()
         while True:
             try:
                 server_output += self.shell.read_byte()
@@ -412,7 +416,7 @@ class AbstractSSHClient(object):
         :returns: The read output up and until the `regexp` matches.
         """
         regexp = self._encode(regexp)
-        if isinstance(regexp, basestring):
+        if is_string(regexp):
             regexp = re.compile(regexp)
         return self._read_until(lambda s: regexp.search(s), regexp.pattern)
 
@@ -426,7 +430,7 @@ class AbstractSSHClient(object):
 
         timeout is defined with :py:meth:`open_connection()`
         """
-        if isinstance(regexp, basestring):
+        if is_string(regexp):
             regexp = re.compile(regexp)
         matcher = regexp.search
         expected = regexp.pattern
@@ -827,7 +831,7 @@ class AbstractSFTPClient(object):
             msg = "There were no source files matching '%s'." % source
             raise SSHClientException(msg)
         local_files = self._get_get_file_destinations(remote_files, destination)
-        files = zip(remote_files, local_files)
+        files = list(zip(remote_files, local_files))
         for src, dst in files:
             self._get_file(src, dst)
         return files
@@ -959,7 +963,7 @@ class AbstractSFTPClient(object):
                                                                    destination,
                                                                    path_separator)
         self._create_missing_remote_path(remote_dir)
-        files = zip(local_files, remote_files)
+        files = list(zip(local_files, remote_files))
         for source, destination in files:
             self._put_file(source, destination, mode, newline)
         return files
@@ -1002,21 +1006,21 @@ class AbstractSFTPClient(object):
         return destination.rsplit(path_separator, 1)
 
     def _create_missing_remote_path(self, path):
-        if path.startswith('/'):
-            current_dir = '/'
+        if path.startswith(b'/'):
+            current_dir = b'/'
         else:
-            current_dir = self._absolute_path('.')
-        for dir_name in path.split('/'):
+            current_dir = self._absolute_path('.').encode()
+        for dir_name in path.split(b'/'):
             if dir_name:
                 current_dir = posixpath.join(current_dir, dir_name)
             try:
                 self._client.stat(current_dir)
             except:
-                self._client.mkdir(current_dir, 0744)
+                self._client.mkdir(current_dir, 0o744)
 
     def _put_file(self, source, destination, mode, newline):
         remote_file = self._create_remote_file(destination, mode)
-        with open(source, 'rb') as local_file:
+        with open(source, 'r') as local_file:
             position = 0
             while True:
                 data = local_file.read(4096)

--- a/src/SSHLibrary/client.py
+++ b/src/SSHLibrary/client.py
@@ -15,6 +15,6 @@
 import sys
 
 if sys.platform.startswith('java'):
-    from javaclient import JavaSSHClient as SSHClient
+    from SSHLibrary.javaclient import JavaSSHClient as SSHClient
 else:
-    from pythonclient import PythonSSHClient as SSHClient
+    from SSHLibrary.pythonclient import PythonSSHClient as SSHClient

--- a/src/SSHLibrary/config.py
+++ b/src/SSHLibrary/config.py
@@ -1,7 +1,3 @@
-# from __future__ import absolute_import, division, print_function, with_statement
-# from builtins import str
-# from builtins import object
-
 from robot import utils
 
 

--- a/src/SSHLibrary/config.py
+++ b/src/SSHLibrary/config.py
@@ -1,3 +1,7 @@
+# from __future__ import absolute_import, division, print_function, with_statement
+# from builtins import str
+# from builtins import object
+
 from robot import utils
 
 
@@ -27,7 +31,7 @@ class Configuration(object):
         self._config = entries
 
     def __str__(self):
-        return '\n'.join(['%s=%s' % (k, v) for k, v in self._config.items()])
+        return '\n'.join(['%s=%s' % (k, v) for k, v in list(self._config.items())])
 
     def update(self, **entries):
         """Update configuration entries.
@@ -38,7 +42,7 @@ class Configuration(object):
 
         See `__init__` for an example.
         """
-        for name, value in entries.items():
+        for name, value in list(entries.items()):
             if value is not None:
                 self._config[name].set(value)
 

--- a/src/SSHLibrary/javaclient.py
+++ b/src/SSHLibrary/javaclient.py
@@ -12,9 +12,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-# from __future__ import absolute_import, division, print_function, with_statement
-# from builtins import chr
-
 try:
     from com.trilead.ssh2 import (Connection, SFTPException, SFTPv3Client,
                                   SFTPv3DirectoryEntry, StreamGobbler)

--- a/src/SSHLibrary/javaclient.py
+++ b/src/SSHLibrary/javaclient.py
@@ -12,6 +12,9 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+# from __future__ import absolute_import, division, print_function, with_statement
+# from builtins import chr
+
 try:
     from com.trilead.ssh2 import (Connection, SFTPException, SFTPv3Client,
                                   SFTPv3DirectoryEntry, StreamGobbler)
@@ -89,7 +92,7 @@ class Shell(AbstractShell):
     def read_byte(self):
          if self._output_available():
              return chr(self._stdout.read())
-         return ''
+         return bytes()
 
     def _output_available(self):
         return self._stdout.available()

--- a/src/SSHLibrary/library.py
+++ b/src/SSHLibrary/library.py
@@ -12,11 +12,12 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+
 try:
     from robot.api import logger
 except ImportError:
     logger = None
-from robot.utils import ConnectionCache
+from robot.utils import ConnectionCache, is_string
 
 from .abstractclient import SSHClientException
 from .client import SSHClient
@@ -706,12 +707,12 @@ class SSHLibrary(object):
         if logger:
             logger.write(msg, level)
         else:
-            print '*%s* %s' % (level, msg)
+            print('*%s* %s' % (level, msg))
 
     def _active_loglevel(self, level):
         if level is None:
             return self._config.loglevel
-        if isinstance(level, basestring) and \
+        if is_string(level) and \
                 level.upper() in ['TRACE', 'DEBUG', 'INFO', 'WARN', 'HTML']:
             return level.upper()
         raise AssertionError("Invalid log level '%s'." % level)
@@ -832,7 +833,7 @@ class SSHLibrary(object):
             login_output = login_method(username, *args)
             self._log('Read output: %s' % login_output)
             return login_output
-        except SSHClientException, e:
+        except SSHClientException as e:
             raise RuntimeError(e)
 
     def execute_command(self, command, return_stdout=True, return_stderr=False,
@@ -963,12 +964,12 @@ class SSHLibrary(object):
                                            return_rc)
         try:
             stdout, stderr, rc = self.current.read_command_output()
-        except SSHClientException, msg:
+        except SSHClientException as msg:
             raise RuntimeError(msg)
         return self._return_command_output(stdout, stderr, rc, *opts)
 
     def _legacy_output_options(self, stdout, stderr, rc):
-        if not isinstance(stdout, basestring):
+        if not is_string(stdout):
             return stdout, stderr, rc
         stdout = stdout.lower()
         if stdout == 'stderr':
@@ -1039,7 +1040,7 @@ class SSHLibrary(object):
     def _write(self, text, add_newline=False):
         try:
             self.current.write(text, add_newline)
-        except SSHClientException, e:
+        except SSHClientException as e:
             raise RuntimeError(e)
 
     def write_until_expected_output(self, text, expected, timeout,
@@ -1210,7 +1211,7 @@ class SSHLibrary(object):
     def _read_and_log(self, loglevel, reader, *args):
         try:
             output = reader(*args)
-        except SSHClientException, e:
+        except SSHClientException as e:
             raise RuntimeError(e)
         self._log(output, loglevel)
         return output
@@ -1405,7 +1406,7 @@ class SSHLibrary(object):
     def _run_sftp_command(self, command, *args):
         try:
             files = command(*args)
-        except SSHClientException, e:
+        except SSHClientException as e:
             raise RuntimeError(e)
         for src, dst in files:
             self._info("'%s' -> '%s'" % (src, dst))
@@ -1498,7 +1499,7 @@ class SSHLibrary(object):
         """
         try:
             items = self.current.list_dir(path, pattern, absolute)
-        except SSHClientException, msg:
+        except SSHClientException as msg:
             raise RuntimeError(msg)
         self._info('%d item%s:\n%s' % (len(items), plural_or_not(items),
                                        '\n'.join(items)))
@@ -1511,7 +1512,7 @@ class SSHLibrary(object):
         """
         try:
             files = self.current.list_files_in_dir(path, pattern, absolute)
-        except SSHClientException, msg:
+        except SSHClientException as msg:
             raise RuntimeError(msg)
         files = self.current.list_files_in_dir(path, pattern, absolute)
         self._info('%d file%s:\n%s' % (len(files), plural_or_not(files),
@@ -1525,7 +1526,7 @@ class SSHLibrary(object):
         """
         try:
             dirs = self.current.list_dirs_in_dir(path, pattern, absolute)
-        except SSHClientException, msg:
+        except SSHClientException as msg:
             raise RuntimeError(msg)
         self._info('%d director%s:\n%s' % (len(dirs),
                                           'y' if len(dirs) == 1 else 'ies',


### PR DESCRIPTION
Futurized code to run on both Python2 and Python3

Remove __future__ imports from unit tests.

Remove __future__ and builtins imports from source code.
Uses robot.utils is_string, is_integer and unic.

Remove future from setup.py.