### PR TITLE
Custom users

### DIFF
--- a/atest/resources/common.robot
+++ b/atest/resources/common.robot
@@ -7,7 +7,7 @@ ${PASSWORD}               test
 ${HOST}                   localhost
 ${PROMPT}                 $
 ${REMOTE TEST ROOT NAME}  robot-testdir
-${REMOTE TEST ROOT}       /home/test/${REMOTE TEST ROOT NAME}
+${REMOTE TEST ROOT}       /home/${USERNAME}/${REMOTE TEST ROOT NAME}
 ${CYGWIN HOME}            c:/cygwin64
 ${REMOTE WINDOWS TEST ROOT}  ${CYGWIN HOME}${REMOTE TEST ROOT}
 ${LOCAL TESTDATA}         ${CURDIR}${/}..${/}testdata

--- a/atest/run.py
+++ b/atest/run.py
@@ -17,6 +17,7 @@ import sys
 import os
 
 from os.path import abspath, dirname, exists, join, normpath
+from os import environ
 from robot import run_cli, rebot
 from robotstatuschecker import process_output
 
@@ -30,6 +31,20 @@ JAR_PATH = join(CURDIR, '..', 'lib')
 sys.path.append(join(CURDIR, '..', 'src'))
 
 COMMON_OPTS = ('--log', 'NONE', '--report', 'NONE')
+
+USERNAME = environ.get('RFSL_TEST_USERNAME')
+PASSWORD = environ.get('RFSL_TEST_PASSWORD')
+if USERNAME and PASSWORD:
+    COMMON_OPTS += (
+        '--variable', 'USERNAME:' + USERNAME,
+        '--variable', 'PASSWORD:' + PASSWORD
+    )
+
+KEY_USERNAME = environ.get('RFSL_TESTKEY_USERNAME')
+if KEY_USERNAME:
+    COMMON_OPTS += (
+        '--variable', 'KEY_USERNAME:' + KEY_USERNAME
+    )
 
 def atests(*opts):
     if os.name == 'java':

--- a/utest/test_client_api.py
+++ b/utest/test_client_api.py
@@ -1,21 +1,24 @@
+from os import environ
 import unittest
 
 from SSHLibrary import SSHClient
 
+TEST_USERNAME = environ.get('RFSL_TEST_USERNAME', 'test')
+TEST_PASSWORD = environ.get('RFSL_TEST_PASSWORD', 'test')
 
 class TestClienAPI(unittest.TestCase):
 
     def test_login_close_and_login_again(self):
         s = SSHClient('localhost', prompt='$ ')
-        s.login('test', 'test')
+        s.login(TEST_USERNAME, TEST_PASSWORD)
         s.execute_command('ls')
         s.close()
-        s.login('test', 'test')
+        s.login(TEST_USERNAME, TEST_PASSWORD)
         s.execute_command('ls')
 
     def test_read_until_regexp_with_prefix(self):
         s = SSHClient('localhost', prompt='$ ')
-        s.login('test', 'test')
+        s.login(TEST_USERNAME, TEST_PASSWORD)
         s.write('faa')
         s.read_until_regexp_with_prefix(r'foo\sfaa', 'foo ')
         s.close()

--- a/utest/test_scp.py
+++ b/utest/test_scp.py
@@ -2,6 +2,8 @@ import os
 import unittest
 
 from SSHLibrary import abstractclient, SSHClient
+from test_client_api import TEST_USERNAME
+from test_client_api import TEST_PASSWORD
 
 abstractclient.AbstractSFTPClient._absolute_path = lambda obj, path: '/home'
 
@@ -66,7 +68,7 @@ class TestSSHClientGetMethod(unittest.TestCase):
         return client
 
     def _login_client(self, client):
-        client.login('test', 'test')
+        client.login(TEST_USERNAME, TEST_PASSWORD)
 
     def _create_test_dirs(self, client):
         client.execute_command("mkdir -p %s" % self.SRC_DIR)


### PR DESCRIPTION
Many environments are enforcing complex passwords and sometimes you have to specify the user name as HOST+test.

This PR allows custom user names and passwords using env vars:

- RFSL_TEST_USERNAME
- RFSL_TEST_PASSWORD
- RFSL_TESTKEY_USERNAME