### PR TITLE
Custom users

### DIFF
--- a/atest/resources/common.robot
+++ b/atest/resources/common.robot
@@ -3,11 +3,12 @@ Library     SSHLibrary  WITH NAME  SSH
 
 *** Variables ***
 ${USERNAME}               test
+${USERHOME}               test
 ${PASSWORD}               test
 ${HOST}                   localhost
 ${PROMPT}                 $
 ${REMOTE TEST ROOT NAME}  robot-testdir
-${REMOTE TEST ROOT}       /home/test/${REMOTE TEST ROOT NAME}
+${REMOTE TEST ROOT}       /home/${USERHOME}/${REMOTE TEST ROOT NAME}
 ${CYGWIN HOME}            c:/cygwin64
 ${REMOTE WINDOWS TEST ROOT}  ${CYGWIN HOME}${REMOTE TEST ROOT}
 ${LOCAL TESTDATA}         ${CURDIR}${/}..${/}testdata

--- a/atest/run.py
+++ b/atest/run.py
@@ -17,6 +17,7 @@ import sys
 import os
 
 from os.path import abspath, dirname, exists, join, normpath
+from os import environ
 from robot import run_cli, rebot
 from robotstatuschecker import process_output
 
@@ -30,6 +31,25 @@ JAR_PATH = join(CURDIR, '..', 'lib')
 sys.path.append(join(CURDIR, '..', 'src'))
 
 COMMON_OPTS = ('--log', 'NONE', '--report', 'NONE')
+
+def check_environment():
+    global COMMON_OPTS
+    env_prefix = 'RFSL_'
+
+    var_list = [
+        'CYGWIN_HOME',
+        'KEY_USERNAME',
+        'PASSWORD',
+        'USERHOME',
+        'USERNAME',
+    ]
+
+    for var_name in var_list:
+        value = environ.get(env_prefix + var_name)
+        if value:
+            COMMON_OPTS += (
+                '--variable', var_name + ':' + value.strip()
+            )
 
 def atests(*opts):
     if os.name == 'java':
@@ -66,6 +86,7 @@ if __name__ == '__main__':
         print(__doc__)
         rc = 251
     else:
+        check_environment()
         rc = atests(*sys.argv[1:])
     print "\nAfter status check there were %s failures." % rc
     sys.exit(rc)

--- a/utest/test_client_api.py
+++ b/utest/test_client_api.py
@@ -1,21 +1,24 @@
+from os import environ
 import unittest
 
 from SSHLibrary import SSHClient
 
+USERNAME = environ.get('RFSL_USERNAME', 'test')
+PASSWORD = environ.get('RFSL_PASSWORD', 'test')
 
 class TestClienAPI(unittest.TestCase):
 
     def test_login_close_and_login_again(self):
         s = SSHClient('localhost', prompt='$ ')
-        s.login('test', 'test')
+        s.login(USERNAME, PASSWORD)
         s.execute_command('ls')
         s.close()
-        s.login('test', 'test')
+        s.login(USERNAME, PASSWORD)
         s.execute_command('ls')
 
     def test_read_until_regexp_with_prefix(self):
         s = SSHClient('localhost', prompt='$ ')
-        s.login('test', 'test')
+        s.login(USERNAME, PASSWORD)
         s.write('faa')
         s.read_until_regexp_with_prefix(r'foo\sfaa', 'foo ')
         s.close()

--- a/utest/test_scp.py
+++ b/utest/test_scp.py
@@ -2,6 +2,8 @@ import os
 import unittest
 
 from SSHLibrary import abstractclient, SSHClient
+from test_client_api import USERNAME
+from test_client_api import PASSWORD
 
 abstractclient.AbstractSFTPClient._absolute_path = lambda obj, path: '/home'
 
@@ -66,7 +68,7 @@ class TestSSHClientGetMethod(unittest.TestCase):
         return client
 
     def _login_client(self, client):
-        client.login('test', 'test')
+        client.login(USERNAME, PASSWORD)
 
     def _create_test_dirs(self, client):
         client.execute_command("mkdir -p %s" % self.SRC_DIR)


### PR DESCRIPTION
Many environments are enforcing complex passwords and sometimes you have to specify the user name as `HOST123+username` (while the home folder is still named `username`).

This PR allows custom user names and passwords using env vars:

- `RFSL_CYGWIN_HOME`
- `RFSL_KEY_USERNAME`
- `RFSL_PASSWORD`
- `RFSL_USERHOME`
- `RFSL_USERNAME`
