### PR TITLE
Add exception for pythonclient when write method become un-responsible

### DIFF
--- a/src/SSHLibrary/pythonclient.py
+++ b/src/SSHLibrary/pythonclient.py
@@ -115,7 +115,10 @@ class Shell(AbstractShell):
         return self._shell.recv_ready()
 
     def write(self, text):
-        self._shell.sendall(text)
+        try:
+            self._shell.sendall(text)
+        except SSHClientException, e:
+            raise RuntimeError(e)
 
 
 class SFTPClient(AbstractSFTPClient):


### PR DESCRIPTION
I maybe get many unresponsible from the keyword WRITE when  I use the pythonclient to write text to the ssh server that send the commands text largely，frequently，repetitive。