### PR TITLE
Fixed bug with execution of time consuming commands with sudo

### DIFF
--- a/atest/execute_command.robot
+++ b/atest/execute_command.robot
@@ -77,3 +77,8 @@ Execute Sudo Command With Incorrect Password
     [Tags]     linux
     ${stdout} =  Execute Command  -k pwd   sudo=True  sudo_password=test123
     Should Not Contain  ${stdout}  ${REMOTE HOME TEST}
+
+Execute Time Consuming Sudo Command
+    [Tags]     linux
+    ${stdout} =  Execute Command  -k sleep 5; echo cat   sudo=True  sudo_password=test
+    Should Contain  ${stdout}  cat

--- a/atest/start_command.robot
+++ b/atest/start_command.robot
@@ -44,13 +44,19 @@ Reading Command Output Without Command Started
     ...  Read Command Output
 
 Start Sudo Command With Correct Password
-    [Tags]  linux
+    [Tags]     linux
     Start Command  -k pwd   sudo=True  sudo_password=test
     ${stdout} =  Read Command Output
     Should Contain  ${stdout}  ${REMOTE HOME TEST}
 
 Start Sudo Command With Incorrect Password
-    [Tags]  linux
+    [Tags]     linux
     Start Command  -k pwd   sudo=True  sudo_password=test123
     ${stdout} =  Read Command Output
     Should Not Contain  ${stdout}  ${REMOTE HOME TEST}
+
+Start Time Consuming Sudo Command
+    [Tags]     linux
+    Start Command  -k sleep 5; echo cat   sudo=True  sudo_password=test
+    ${stdout} =  Read Command Output
+    Should Contain  ${stdout}  cat

--- a/src/SSHLibrary/pythonclient.py
+++ b/src/SSHLibrary/pythonclient.py
@@ -226,12 +226,7 @@ class RemoteCommand(AbstractCommand):
     def _execute_with_sudo(self, sudo_password=None):
         command = 'sudo ' + self._command.decode(self._encoding)
         self._shell.get_pty()
-        self._shell.exec_command(command)
-        if sudo_password is not None:
-            stdin = self._shell.makefile('wb', -1)
-            stdin.write(sudo_password + '\n')
-            stdin.flush()
-            time.sleep(0.1)  # flags from _shell_open() not updated without this sleep
-            # in case of incorrect password close the shell
-            if self._shell_open():
-                self._shell.close()
+        if sudo_password is None:
+            self._shell.exec_command(command)
+        else:
+            self._shell.exec_command('echo %s | sudo --stdin --prompt "" %s' % (sudo_password, command))


### PR DESCRIPTION
This PR contains a fix for https://github.com/robotframework/SSHLibrary/issues/230.
Thank you @apolotsk for your opening the issue.

I've changed a bit the logic of the execution with `sudo`. The password will be read from `stdin` now and if it's incorrect, the shell will automatically close.

Two acceptance tests were added for this scenario.