### PR TITLE
Open session timeout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ matrix:
     - python: "3.6"
       env:
         - ROBOTFRAMEWORK=3.0.2
-        - PARAMIKO=1.15.0
+        - PARAMIKO=1.15.3
 before_script:
   - pip install robotframework==$ROBOTFRAMEWORK
   - if [ "$JYTHON" == "true" ]; then

--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,7 @@ The recommended installation method is using pip_::
     pip install --upgrade robotframework-sshlibrary
 
 Running this command installs also the latest Robot Framework and paramiko_
-versions. The minimum supported paramiko version is ``1.15.0``.
+versions. The minimum supported paramiko version is ``1.15.3``.
 The ``--upgrade`` option can be omitted when installing the library for the
 first time.
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup
 CURDIR = dirname(abspath(__file__))
 REQUIREMENTS = ['robotframework >= 3.0']
 if not sys.platform.startswith('java'):
-    REQUIREMENTS.append('paramiko >= 1.15.0')
+    REQUIREMENTS.append('paramiko >= 1.15.3')
 with open(join(CURDIR, 'src', 'SSHLibrary', 'version.py')) as f:
     VERSION = re.search("\nVERSION = '(.*)'", f.read()).group(1)
 with open(join(CURDIR, 'README.rst')) as f:

--- a/src/SSHLibrary/pythonclient.py
+++ b/src/SSHLibrary/pythonclient.py
@@ -102,7 +102,7 @@ class PythonSSHClient(AbstractSSHClient):
         transport = self.client.get_transport()
         if not transport:
             raise AssertionError("Connection not open")
-        new_shell = transport.open_session()
+        new_shell = transport.open_session(timeout=float(self.config.timeout))
         cmd.run_in(new_shell, sudo, sudo_password)
         return cmd
 


### PR DESCRIPTION
PR for https://github.com/robotframework/SSHLibrary/issues/206.

The proposed change is passing the user configurable SSHLibrary `timeout` argument to the `paramiko.transport.Transport.open_session()` method, when executing a command.

If `timeout=None` the paramiko default of 3600 seconds will be used. 

The `timeout` argument was added in paramiko in version 1.15.3 and SSHLibrary currently lists 1.15.0 as minimum.  As a result, the next version of SSHLibrary will have paramiko 1.15.3 as a minimum requirement.