### PR TITLE
Fix switching to closed connection and keep indices

### DIFF
--- a/atest/connections.robot
+++ b/atest/connections.robot
@@ -70,17 +70,51 @@ Switch Connection When Previous Connection Was Closed
     Open Connection  ${HOST}  alias=alias2
     Switch Connection  alias1
     Close Connection
+    Connection Should Be Closed
     ${old_index}=  Switch Connection  alias2
     Should Be Equal As Strings  ${old_index}  None
+    Run Keyword And Expect Error  Non-existing index or alias 'alias1'.  Switch Connection  alias1
+    ${conn}=  Get Connection
+    Should Be Equal As Strings  ${conn.index}  2
+    Should Be Equal As Strings  ${conn.alias}  alias2
 
 Switch Connection Using Index When Previous Connection Was Closed
     Open Connection  ${HOST}
     Open Connection  ${HOST}
     Switch Connection  1
     Close Connection
+    Connection Should Be Closed
     Switch Connection  2
     ${conn}=  Get Connection  2
     Should Be Equal As Strings  ${conn.index}  2
+    Run Keyword And Expect Error  Non-existing index or alias '1'.  Switch Connection  1
+    ${conn}=  Get Connection
+    Should Be Equal As Strings  ${conn.index}  2
+
+Open Connection When Previous Connection Was Closed
+    Open Connection  ${HOST}  alias=alias1
+    Close Connection
+    Connection Should Be Closed
+    ${idx}=  Open Connection  ${HOST}  alias=alias2
+    Should Be Equal  ${idx}  ${2}
+    ${conn}=  Get Connection  2
+    Should Be Equal  ${conn.index}  ${2}
+    Should Be Equal  ${conn.alias}  alias2
+    ${conn}=  Get Connection  alias2
+    Should Be Equal  ${conn.index}  ${2}
+    Should Be Equal  ${conn.alias}  alias2
+
+Reuse Closed Connection Alias
+    Open Connection  ${HOST}  alias=alias1
+    Close Connection
+    Connection Should Be Closed
+    Open Connection  ${HOST}  alias=alias1
+    ${conn}=  Get Connection  2
+    Should Be Equal  ${conn.index}  ${2}
+    Should Be Equal  ${conn.alias}  alias1
+    ${conn}=  Get Connection  alias1
+    Should Be Equal  ${conn.index}  ${2}
+    Should Be Equal  ${conn.alias}  alias1
 
 Connection To Host Read From SSH Config File
    [Tags]  pybot

--- a/atest/get_connection.robot
+++ b/atest/get_connection.robot
@@ -28,6 +28,21 @@ Get Connection When No Connection Is Open
     Should Be Equal As Integers  ${conn.width}   80
     Should Be Equal As Integers  ${conn.height}  24
 
+Get Connection Closed
+    Open Connection   ${HOST}  alias=alias1
+    Close Connection
+    ${conn}=  Get Connection  1
+    Should Be Equal   ${conn.host}               ${None}
+    Should Be Equal   ${conn.index}              ${None}
+    Should Be Equal   ${conn.alias}              ${None}
+    Should Be Equal   ${conn.prompt}             ${None}
+    Should Be Equal As Integers  ${conn.port}    22
+    Should Be Equal As Strings   ${conn.newline}   \n
+    Should Be Equal   ${conn.encoding}           utf8
+    Should Be Equal   ${conn.term_type}          vt100
+    Should Be Equal As Integers  ${conn.width}   80
+    Should Be Equal As Integers  ${conn.height}  24
+
 Get Connection Index Only
     Open Connection  ${HOST}
     ${index}=  Get Connection  index=True
@@ -52,7 +67,32 @@ Get Connections
     Should Be Equal    ${conns[1].alias}      another
     Should Be Equal    ${conns[0].term_type}  vt100
 
+Get Connections Returns Only Open Connections
+    Open Connection   ${HOST}   prompt=>>
+    Open Connection   ${HOST}   alias=to_be_closed
+    Open Connection   ${HOST}   alias=another
+    Switch Connection  to_be_closed
+    Close Connection
+    ${conns} =   Get Connections
+    Length Should Be   ${conns}  2
+    Should Be Equal As Integers   ${conns[0].index}   1
+    Should Be Equal As Integers   ${conns[1].index}   3
+    Should Be Equal    ${conns[0].host}       ${HOST}
+    Should Be Equal    ${conns[1].host}       ${HOST}
+    Should Be Equal    ${conns[0].prompt}     >>
+    Should Be Equal    ${conns[1].alias}      another
+    Should Be Equal    ${conns[0].term_type}  vt100
+
 Get Connections Returns Empty List When No Connections
+    ${conns} =  Get Connections
+    ${empty_list} =  Create List
+    Should Be Equal  ${conns}  ${empty_list}
+
+Get Connections Returns Empty List When All Connections Are Closed
+    Open Connection  ${HOST}
+    Close Connection
+    Open Connection  ${HOST}
+    Close Connection
     ${conns} =  Get Connections
     ${empty_list} =  Create List
     Should Be Equal  ${conns}  ${empty_list}

--- a/src/SSHLibrary/library.py
+++ b/src/SSHLibrary/library.py
@@ -851,7 +851,7 @@ class SSHLibrary(object):
         This keyword logs the information of connections with log level
         ``INFO``.
         """
-        configs = [c.config for c in self._connections._connections]
+        configs = [c.config for c in self._connections._connections if c]
         for c in configs:
             self._log(str(c), self._config.loglevel)
         return configs


### PR DESCRIPTION
Fix for #304 which also maintains connection indices.

On `close_current` connection is replaced inside cache with `NoConnection` instance - always the same (referenced by `self._no_current`). Drawback is that list size will be increasing over time with more connections opened/closed, but at least it should be relatively cheap compared to `robot.utils.ConnectionCache`, which always stores original connection instances.