### PR TITLE
Don't open SFTP connection if scp=ALL was requested (#329)

### DIFF
--- a/src/SSHLibrary/abstractclient.py
+++ b/src/SSHLibrary/abstractclient.py
@@ -677,9 +677,12 @@ class AbstractSSHClient(object):
         return self.sftp_client.is_file(path)
 
     def _create_client(self, scp):
-        return {'OFF': self.sftp_client,
-                'TRANSFER': self.scp_transfer_client,
-                'ALL': self.scp_all_client}.get(scp.upper(), self.sftp_client)
+        if scp.upper() == 'ALL':
+            return self.scp_all_client
+        elif scp.upper() == 'TRANSFER':
+            return self.scp_transfer_client
+        else:
+            return self.sftp_client
 
 
 class AbstractShell(object):


### PR DESCRIPTION
Fixes #329  

In the previous implementation all the dictionary values are
evaluated and the one requested is returned. This causes an attempt
to open SFTP connection and an exception if the targer server doesn't
have sftp server which is the case with many embedded system.