### PR TITLE
Jump host functionality

### DIFF
--- a/src/SSHLibrary/abstractclient.py
+++ b/src/SSHLibrary/abstractclient.py
@@ -219,7 +219,8 @@ class AbstractSSHClient(object):
         return self.read_until_prompt()
 
     def login_with_public_key(self, username, keyfile, password, allow_agent=False,
-                              look_for_keys=False, delay=None, proxy_cmd=None):
+                              look_for_keys=False, delay=None, proxy_cmd=None,
+                              jumphost_connection=None):
         """Logs into the remote host using the public key authentication.
 
         This method reads the output from the remote host after logging in,
@@ -246,6 +247,10 @@ class AbstractSSHClient(object):
             the prompt is not set.
 
         :param str proxy_cmd : Proxy command
+        
+        :param PythonSSHClient jumphost_connection : An instance of
+            PythonSSHClient that is will be used as an intermediary jump-host
+            for the SSH connection being attempted.
 
         :raises SSHClientException: If logging in failed.
 
@@ -256,7 +261,7 @@ class AbstractSSHClient(object):
         try:
             self._login_with_public_key(username, keyfile, password,
                                         allow_agent, look_for_keys,
-                                        proxy_cmd)
+                                        proxy_cmd, jumphost_connection)
         except SSHClientException:
             self.client.close()
             raise SSHClientException("Login with public key failed for user "
@@ -273,7 +278,8 @@ class AbstractSSHClient(object):
             raise SSHClientException("Could not read key file '%s'." % keyfile)
 
     def _login_with_public_key(self, username, keyfile, password,
-                               allow_agent, look_for_keys, proxy_cmd):
+                               allow_agent, look_for_keys, proxy_cmd,
+                               jumphost_index_or_alias):
         raise NotImplementedError
 
     @staticmethod

--- a/src/SSHLibrary/javaclient.py
+++ b/src/SSHLibrary/javaclient.py
@@ -60,10 +60,10 @@ class JavaSSHClient(AbstractSSHClient):
     def enable_logging(logfile):
         return False
 
-    def _login(self, username, password, allow_agent='ignored', look_for_keys='ignored', proxy_cmd=None):
+    def _login(self, username, password, allow_agent='ignored', look_for_keys='ignored', proxy_cmd=None, jumphost_alias_or_index=None):
         if allow_agent or look_for_keys:
-            raise JavaSSHClientException("Arguments 'allow_agent' and "
-                                         "'look_for_keys' do not work with Jython.")
+            raise JavaSSHClientException("Arguments 'allow_agent', 'look_for_keys', and "
+                                         "`jumphost_index_or_alias` do not work with Jython.")
         if not self.client.authenticateWithPassword(username, password):
             raise SSHClientException
 

--- a/src/SSHLibrary/javaclient.py
+++ b/src/SSHLibrary/javaclient.py
@@ -60,7 +60,8 @@ class JavaSSHClient(AbstractSSHClient):
     def enable_logging(logfile):
         return False
 
-    def _login(self, username, password, allow_agent='ignored', look_for_keys='ignored', proxy_cmd=None, jumphost_alias_or_index=None):
+    def _login(self, username, password, allow_agent='ignored', look_for_keys='ignored',
+               proxy_cmd=None, jumphost_alias_or_index=None):
         if allow_agent or look_for_keys:
             raise JavaSSHClientException("Arguments 'allow_agent', 'look_for_keys', and "
                                          "`jumphost_index_or_alias` do not work with Jython.")
@@ -68,10 +69,11 @@ class JavaSSHClient(AbstractSSHClient):
             raise SSHClientException
 
     def _login_with_public_key(self, username, key_file, password,
-                               allow_agent='ignored', look_for_keys='ignored', proxy_cmd=None):
+                               allow_agent='ignored', look_for_keys='ignored',
+                               proxy_cmd=None, jumphost_alias_or_index=None):
         if allow_agent or look_for_keys:
-            raise JavaSSHClientException("Arguments 'allow_agent' and "
-                                         "'look_for_keys' do not work with Jython.")
+            raise JavaSSHClientException("Arguments 'allow_agent', 'look_for_keys', and "
+                                         "`jumphost_index_or_alias` do not work with Jython.")
         try:
             success = self.client.authenticateWithPublicKey(username,
                                                             File(key_file),

--- a/src/SSHLibrary/library.py
+++ b/src/SSHLibrary/library.py
@@ -915,7 +915,8 @@ class SSHLibrary(object):
 
     def login_with_public_key(self, username, keyfile, password='',
                               allow_agent=False, look_for_keys=False,
-                              delay='0.5 seconds', proxy_cmd=None):
+                              delay='0.5 seconds', proxy_cmd=None,
+                              jumphost_index_or_alias=None):
         """Logs into the SSH server using key-based authentication.
 
         Connection must be opened before using this keyword.
@@ -929,6 +930,9 @@ class SSHLibrary(object):
         invalid a username-password authentication will be attempted.
 
         ``proxy_cmd`` is used to connect through a SSH proxy.
+
+        ``jumphost_index_or_alias`` is used to connect through an intermediary
+        SSH connection that has been assigned an Index or Alias.
 
         This keyword reads, returns and logs the server output after logging
         in. If the `prompt` is set, everything until the prompt is read.
@@ -953,11 +957,14 @@ class SSHLibrary(object):
         ``allow_agent`` and ``look_for_keys`` arguments are new in SSHLibrary
         3.0.0.
 
-        *Note:* ``allow_agent``, ``look_for_keys`` and ``proxy_cmd`` do not work when using Jython.
+        *Note:* ``allow_agent``, ``look_for_keys``, ``proxy_cmd``, and
+        ``jumphost_index_or_alias`` do not work when using Jython.
         """
+        jumphost_connection_conf = self.get_connection(index_or_alias=jumphost_index_or_alias) if jumphost_index_or_alias else None
+        jumphost_connection = self._connections.connections[jumphost_connection_conf.index-1] if jumphost_connection_conf and jumphost_connection_conf.index else None
         return self._login(self.current.login_with_public_key, username,
                            keyfile, password, is_truthy(allow_agent),
-                           is_truthy(look_for_keys), delay, proxy_cmd)
+                           is_truthy(look_for_keys), delay, proxy_cmd, jumphost_connection)
 
     def _login(self, login_method, username, *args):
         self._log("Logging into '%s:%s' as '%s'."

--- a/src/SSHLibrary/library.py
+++ b/src/SSHLibrary/library.py
@@ -932,7 +932,13 @@ class SSHLibrary(object):
         ``proxy_cmd`` is used to connect through a SSH proxy.
 
         ``jumphost_index_or_alias`` is used to connect through an intermediary
-        SSH connection that has been assigned an Index or Alias.
+        SSH connection that has been assigned an Index or Alias. Note that
+        this requires a Connection that has been logged in prior to use.
+
+        *Note:* ``proxy_cmd`` and ``jumphost_index_or_alias`` are mutually
+        exclusive SSH features. If you wish to use them both, create the
+        jump-host's Connection using the proxy_cmd first, then use jump-host
+        for secondary Connection.
 
         This keyword reads, returns and logs the server output after logging
         in. If the `prompt` is set, everything until the prompt is read.
@@ -960,6 +966,8 @@ class SSHLibrary(object):
         *Note:* ``allow_agent``, ``look_for_keys``, ``proxy_cmd``, and
         ``jumphost_index_or_alias`` do not work when using Jython.
         """
+        if proxy_cmd and jumphost_index_or_alias:
+            raise ValueError("`proxy_cmd` and `jumphost_connection` are mutually exclusive SSH features.")
         jumphost_connection_conf = self.get_connection(index_or_alias=jumphost_index_or_alias) if jumphost_index_or_alias else None
         jumphost_connection = self._connections.connections[jumphost_connection_conf.index-1] if jumphost_connection_conf and jumphost_connection_conf.index else None
         return self._login(self.current.login_with_public_key, username,

--- a/src/SSHLibrary/pythonclient.py
+++ b/src/SSHLibrary/pythonclient.py
@@ -117,7 +117,12 @@ class PythonSSHClient(AbstractSSHClient):
             elif jumphost_connection and not proxy_cmd:
                 dest_addr = (self.config.host, self.config.port)
                 jump_addr = (jumphost_connection.config.host, jumphost_connection.config.port)
-                sock_tunnel = jumphost_connection.client.get_transport().open_channel("direct-tcpip", dest_addr, jump_addr)
+                jumphost_transport = jumphost_connection.client.get_transport()
+                if not jumphost_transport:
+                    raise RuntimeError("Could not get transport for {}:{}. Have you logged in?".format(*jump_addr))
+                sock_tunnel = jumphost_transport.open_channel("direct-tcpip", dest_addr, jump_addr)
+            elif proxy_cmd and jumphost_connection:
+                raise ValueError("`proxy_cmd` and `jumphost_connection` are mutually exclusive SSH features.")
             self.client.connect(self.config.host, self.config.port, username,
                                 password, key_filename=key_file,
                                 allow_agent=allow_agent,


### PR DESCRIPTION
This PR is for adding jump-host functionality so you can SSH into systemA to subsequent SSH into systemB for remote execution. This leverages the index_or_alias feature to allow you to create an SSH connection with SSHLibrary through normal means and without re-typing in the details, to utilize it as a jump-host. 

Example usage:
```
| Open Connection       | ${systemA_IP}           | port=${systemA_Port}             | alias=systemA
| Login With Public Key | ${systemA_user}       | /dev/null             | allow_agent=True
#This is the Jump-host's Connection

| Open Connection       | ${systemB_IP}            | port=${systemB_Port}             | alias=systemB
| Login With Public Key | ${systemB_IP}           | /dev/null             | allow_agent=True      | look_for_keys=True    | jumphost_index_or_alias=systemA
#This is the Connection created using the Jump-host.
```

Note: you have to actually Login to systemA, or a transport will not be created and thus jump-hosting won't work. Appropriate error-handling has been created to compensate for this. Additionally, the `proxy_cmd` and `jumphost_index_or_alias` keywords are mutually exclusive concepts. If you need to leverage `proxy_cmd`, utilize it on systemA, and then use systemA as a jump-host like normal.