### PR TITLE
Pr/347

### DIFF
--- a/src/SSHLibrary/abstractclient.py
+++ b/src/SSHLibrary/abstractclient.py
@@ -442,7 +442,7 @@ class AbstractSSHClient(object):
             output += self.read_char()
             if matcher(output):
                 return output
-            time.sleep(.00001) # Release GIL so paramiko I/O thread can run
+            time.sleep(0) # Release GIL so paramiko I/O thread can run
         raise SSHClientException("No match found for '%s' in %s\nOutput:\n%s."
                                  % (expected, timeout, output))
 

--- a/src/SSHLibrary/abstractclient.py
+++ b/src/SSHLibrary/abstractclient.py
@@ -439,7 +439,7 @@ class AbstractSSHClient(object):
         timeout = TimeEntry(timeout) if timeout else self.config.get('timeout')
         max_time = time.time() + timeout.value
         while time.time() < max_time:
-            output += self.read_char()
+            output += self.read()
             if matcher(output):
                 return output
             time.sleep(.00001) # Release GIL so paramiko I/O thread can run

--- a/src/SSHLibrary/abstractclient.py
+++ b/src/SSHLibrary/abstractclient.py
@@ -442,6 +442,7 @@ class AbstractSSHClient(object):
             output += self.read_char()
             if matcher(output):
                 return output
+            time.sleep(.00001) # Release GIL so paramiko I/O thread can run
         raise SSHClientException("No match found for '%s' in %s\nOutput:\n%s."
                                  % (expected, timeout, output))
 

--- a/src/SSHLibrary/abstractclient.py
+++ b/src/SSHLibrary/abstractclient.py
@@ -442,7 +442,7 @@ class AbstractSSHClient(object):
             output += self.read_char()
             if matcher(output):
                 return output
-            time.sleep(0) # Release GIL so paramiko I/O thread can run
+            time.sleep(.00001) # Release GIL so paramiko I/O thread can run
         raise SSHClientException("No match found for '%s' in %s\nOutput:\n%s."
                                  % (expected, timeout, output))
 


### PR DESCRIPTION
Hi @mihaiparvu ,
[issue_347_observation.docx](https://github.com/robotframework/SSHLibrary/files/4870474/issue_347_observation.docx)
### Scripts used:
[scripts.zip](https://github.com/robotframework/SSHLibrary/files/4870491/scripts.zip)
### Steps to run the script:
1.	Place the large.html in any of the remote ssh machine under /tmp/ directory
2.	Provide the ip, username & credentials in test.py 
```
host = "foo@bar.com"
username = "foo"
password = "bar"
```
3.	Run the robot command
`robot .\ssh_lib_test.robot `

we have tested it in windows, linux & macintosh the results are consistent
•	As an alternative we tried 
`taskset -c 0 time robot ssh_lib_test.robot`
•	Also, we tried inside docker with alpine linux same issue appears.

```
Ssh Lib Test                                                          | FAIL |
1 critical test, 0 passed, 1 failed
1 test total, 0 passed, 1 failed
==============================================================================`
Output:  /opt/vntaf/output.xml
Log:     /opt/vntaf/log.html
Report:  /opt/vntaf/report.html
Command exited with non-zero status 1
real    0m 31.96s
user    0m 30.62s
sys     0m 0.09s
```
### Observations in our system:

1.	First option tried: To include time.sleep(0.00001) or time.sleep(0) in _read_until function of abstractclient.py(SSHLibrary) --- Didn’t work
2.	Changed the SSHLibrary.pythonclient.Shell.read_byte to 500 – Works but not sure whether a proper solution

```
    def read(self):
        data = b''
        while self._output_available():
            data += self._shell.recv(4096)
        return data

    def read_byte(self):
         if self._output_available():
            return self._shell.recv(5000)
         return b''
```
Regards,
Sathish