### PR TITLE
Add -p parameter when transfering file with SCP

### DIFF
--- a/atest/get_directory.robot
+++ b/atest/get_directory.robot
@@ -91,6 +91,23 @@ Get Directory containing a symlink
    OS.File Should Exist  ${LOCAL TMPDIR}${/}symlink${/}${SYMLINK TO TEST FILE}
    [Teardown]  Remove Directory  ${LOCAL TMPDIR}  recursive=True
 
+Get Directory With SCP (transfer) And Preserve Time
+    [Setup]  Create Directory  ${LOCAL TMPDIR}
+    Get Directory  ${REMOTE TEST ROOT}  ${LOCAL TMPDIR}  scp=TRANSFER  scp_preserve_times=True
+    Sleep  60s
+    Directory Should Exist With Content  ${LOCAL TMPDIR}  ${/}robot-testdir
+    ${alo} =  Run  stat ${TEMPDIR}${/}robot-sshlibrary-test-tmpdir${/}robot-testdir
+    [Teardown]  Remove Directory  ${LOCAL TMPDIR}  recursive=True
+
+Get Directory With SCP (all) And Preserve Time
+    [Tags]  pybot
+    [Setup]  Create Directory  ${LOCAL TMPDIR}
+    Get Directory  ${REMOTE TEST ROOT}  ${LOCAL TMPDIR}  scp=ALL  scp_preserve_times=True
+    Sleep  60s
+    Directory Should Exist Including Subdirectories  ${LOCAL TMPDIR}  ${/}robot-testdir
+    ${alo} =  Run  stat ${/}robot-testdir
+    [Teardown]  Remove Directory  ${LOCAL TMPDIR}  recursive=True
+
 *** Keywords ***
 File content should be
     [Arguments]    ${file}    ${expected}

--- a/atest/get_directory.robot
+++ b/atest/get_directory.robot
@@ -94,7 +94,7 @@ Get Directory containing a symlink
 
 Get Directory With SCP (transfer) And Preserve Time
     [Setup]  Create Directory  ${LOCAL TMPDIR}
-    Sleep  60s
+    Sleep  15s
     ${current_time} =  Get Current Date  result_format=epoch  exclude_millis=True
     Get Directory  ${REMOTE TEST ROOT}  ${LOCAL TMPDIR}  scp=TRANSFER  scp_preserve_times=True
     Directory Should Exist With Content  ${LOCAL TMPDIR}  ${/}robot-testdir
@@ -107,7 +107,7 @@ Get Directory With SCP (transfer) And Preserve Time
 Get Directory With SCP (all) And Preserve Time
     [Tags]  pybot
     [Setup]  Create Directory  ${LOCAL TMPDIR}
-    Sleep  60s
+    Sleep  15s
     ${current_time} =  Get Current Date  result_format=epoch  exclude_millis=True
     Get Directory  ${REMOTE TEST ROOT}  ${LOCAL TMPDIR}  scp=ALL  scp_preserve_times=True
     Directory Should Exist Including Subdirectories  ${LOCAL TMPDIR}  ${/}robot-testdir

--- a/atest/get_directory.robot
+++ b/atest/get_directory.robot
@@ -4,6 +4,7 @@ Resource        resources/sftp.robot
 Suite Setup     Login and Upload Test Files
 Suite Teardown  Remove Test Files And Close Connections
 Library         OperatingSystem  WITH NAME  OS
+Library         DateTime
 
 *** Test Cases ***
 Get Directory To Existing Local Path
@@ -93,19 +94,27 @@ Get Directory containing a symlink
 
 Get Directory With SCP (transfer) And Preserve Time
     [Setup]  Create Directory  ${LOCAL TMPDIR}
-    Get Directory  ${REMOTE TEST ROOT}  ${LOCAL TMPDIR}  scp=TRANSFER  scp_preserve_times=True
     Sleep  60s
+    ${current_time} =  Get Current Date  result_format=epoch  exclude_millis=True
+    Get Directory  ${REMOTE TEST ROOT}  ${LOCAL TMPDIR}  scp=TRANSFER  scp_preserve_times=True
     Directory Should Exist With Content  ${LOCAL TMPDIR}  ${/}robot-testdir
-    ${alo} =  Run  stat ${TEMPDIR}${/}robot-sshlibrary-test-tmpdir${/}robot-testdir
+    ${last_access_time} =  Run  stat -c %X ${LOCAL TMPDIR}${/}robot-testdir/test_file.txt
+    ${last_modify_time} =  Run  stat -c %X ${LOCAL TMPDIR}${/}robot-testdir/test_file.txt
+    Should Be True  ${current_time} > ${last_access_time}
+    Should Be True  ${current_time} > ${last_modify_time}
     [Teardown]  Remove Directory  ${LOCAL TMPDIR}  recursive=True
 
 Get Directory With SCP (all) And Preserve Time
     [Tags]  pybot
     [Setup]  Create Directory  ${LOCAL TMPDIR}
-    Get Directory  ${REMOTE TEST ROOT}  ${LOCAL TMPDIR}  scp=ALL  scp_preserve_times=True
     Sleep  60s
+    ${current_time} =  Get Current Date  result_format=epoch  exclude_millis=True
+    Get Directory  ${REMOTE TEST ROOT}  ${LOCAL TMPDIR}  scp=ALL  scp_preserve_times=True
     Directory Should Exist Including Subdirectories  ${LOCAL TMPDIR}  ${/}robot-testdir
-    ${alo} =  Run  stat ${/}robot-testdir
+    ${last_access_time} =  Run  stat -c %X ${LOCAL TMPDIR}${/}robot-testdir
+    ${last_modify_time} =  Run  stat -c %X ${LOCAL TMPDIR}${/}robot-testdir
+    Should Be True  ${current_time} > ${last_access_time}
+    Should Be True  ${current_time} > ${last_modify_time}
     [Teardown]  Remove Directory  ${LOCAL TMPDIR}  recursive=True
 
 *** Keywords ***

--- a/atest/get_file.robot
+++ b/atest/get_file.robot
@@ -89,6 +89,22 @@ Get File That Is A Symlink Directory
     OS.File Should Not Exist  symlink_dir
     [Teardown]  OS.Remove File  ${TEST FILE NAME}
 
+Get File With SCP (transfer) And Preserve Time
+    [Setup]  Create Tmp Dir And Move File
+    Sleep  60s
+    SSH.Get File  /tmp/test_file.txt  ${LOCAL TMPDIR}${/}  scp=TRANSFER  scp_preserve_times=True
+    OS.File Should Exist  ${LOCAL TMPDIR}${/}test_file.txt
+    ${alo} =  Run  stat ${LOCAL TMPDIR}${/}test_file.txt
+    [Teardown]  Remove Tmp Dir And Remote File
+
+Get File With SCP (all) And Preserve Time
+    [Setup]  Create Tmp Dir And Move File
+    Sleep  60s
+    SSH.Get File  /tmp/test_file.txt  ${LOCAL TMPDIR}${/}  scp=ALL  scp_preserve_times=True
+    OS.File Should Exist  ${LOCAL TMPDIR}${/}test_file.txt
+    ${alo} =  Run  stat ${LOCAL TMPDIR}${/}test_file.txt
+    [Teardown]  Remove Tmp Dir And Remote File
+
 *** Keywords ***
 Create Tmp Dir And Move File
     Put File  ${TEST FILE}  /tmp/

--- a/atest/get_file.robot
+++ b/atest/get_file.robot
@@ -92,7 +92,7 @@ Get File That Is A Symlink Directory
 
 Get File With SCP (transfer) And Preserve Time
     [Setup]  Create Tmp Dir And Move File
-    Sleep  60s
+    Sleep  15s
     ${current_time} =  Get Current Date  result_format=epoch  exclude_millis=True
     SSH.Get File  /tmp/test_file.txt  ${LOCAL TMPDIR}${/}  scp=TRANSFER  scp_preserve_times=True
     OS.File Should Exist  ${LOCAL TMPDIR}${/}test_file.txt
@@ -104,7 +104,7 @@ Get File With SCP (transfer) And Preserve Time
 
 Get File With SCP (all) And Preserve Time
     [Setup]  Create Tmp Dir And Move File
-    Sleep  60s
+    Sleep  15s
     ${current_time} =  Get Current Date  result_format=epoch  exclude_millis=True
     SSH.Get File  /tmp/test_file.txt  ${LOCAL TMPDIR}${/}  scp=ALL  scp_preserve_times=True
     OS.File Should Exist  ${LOCAL TMPDIR}${/}test_file.txt

--- a/atest/get_file.robot
+++ b/atest/get_file.robot
@@ -5,6 +5,7 @@ Suite Setup     Login and Upload Test Files
 Suite Teardown  Remove Test Files And Close Connections
 Test Teardown   Remove Directory  ${LOCAL TMPDIR}  yes
 Library         OperatingSystem  WITH NAME  OS
+Library         DateTime
 
 *** Test Cases ***
 Get File Using Absolute Source
@@ -92,17 +93,25 @@ Get File That Is A Symlink Directory
 Get File With SCP (transfer) And Preserve Time
     [Setup]  Create Tmp Dir And Move File
     Sleep  60s
+    ${current_time} =  Get Current Date  result_format=epoch  exclude_millis=True
     SSH.Get File  /tmp/test_file.txt  ${LOCAL TMPDIR}${/}  scp=TRANSFER  scp_preserve_times=True
     OS.File Should Exist  ${LOCAL TMPDIR}${/}test_file.txt
-    ${alo} =  Run  stat ${LOCAL TMPDIR}${/}test_file.txt
-    [Teardown]  Remove Tmp Dir And Remote File
+    ${last_access_time} =  Run  stat -c %X ${LOCAL TMPDIR}${/}test_file.txt
+    ${last_modify_time} =  Run  stat -c %X ${LOCAL TMPDIR}${/}test_file.txt
+    Should Be True  ${current_time} > ${last_access_time}
+    Should Be True  ${current_time} > ${last_modify_time}
+#    [Teardown]  Remove Tmp Dir And Remote File
 
 Get File With SCP (all) And Preserve Time
     [Setup]  Create Tmp Dir And Move File
     Sleep  60s
+    ${current_time} =  Get Current Date  result_format=epoch  exclude_millis=True
     SSH.Get File  /tmp/test_file.txt  ${LOCAL TMPDIR}${/}  scp=ALL  scp_preserve_times=True
     OS.File Should Exist  ${LOCAL TMPDIR}${/}test_file.txt
-    ${alo} =  Run  stat ${LOCAL TMPDIR}${/}test_file.txt
+    ${last_access_time} =  Run  stat -c %X ${LOCAL TMPDIR}${/}test_file.txt
+    ${last_modify_time} =  Run  stat -c %X ${LOCAL TMPDIR}${/}test_file.txt
+    Should Be True  ${current_time} > ${last_access_time}
+    Should Be True  ${current_time} > ${last_modify_time}
     [Teardown]  Remove Tmp Dir And Remote File
 
 *** Keywords ***

--- a/atest/put_directory.robot
+++ b/atest/put_directory.robot
@@ -5,6 +5,7 @@ Suite Setup     Login As Valid User
 Suite Teardown  Close All Connections
 Library         OperatingSystem  WITH NAME  OS
 Library         Collections
+Library         DateTime
 
 *** Test Cases ***
 Put Directory To Existing Remote Path
@@ -82,15 +83,23 @@ Put Directory And Check For Proper Permissions
 	[Teardown]  Execute Command  rm -rf ${CURDIR}${/}testdata${/}to_put
 
 Put Directory With SCP (transfer) And Preserve Time
+    ${current_time} =  Get Current Date  result_format=epoch  exclude_millis=True
     Put Directory  ${LOCAL TEXTFILES}  .  recursive=True  scp=TRANSFER  scp_preserve_times=True
     Remote Directory Should Exist With Subdirectories  ./textfiles
-     ${alo} =  Execute Command  stat ./textfiles
-#    [Teardown]  Execute Command  rm -rf ./textfiles
+    ${last_access_time} =  Execute Command  stat -c %X ./textfiles/test_file.txt
+    ${last_modify_time} =  Execute Command  stat -c %X ./textfiles/test_file.txt
+    Should Be True  ${current_time} > ${last_access_time}
+    Should Be True  ${current_time} > ${last_modify_time}
+    [Teardown]  Execute Command  rm -rf ./textfiles
 
 Put Directory With SCP (all) And Preserve Time
     [Tags]  pybot
+    ${current_time} =  Get Current Date  result_format=epoch  exclude_millis=True
     Put Directory  ${LOCAL TEXTFILES}  .  recursive=True  scp=ALL  scp_preserve_times=True
-    ${alo} =  Execute Command  stat ./textfiles
+    ${last_access_time} =  Execute Command  stat -c %X ./textfiles
+    ${last_modify_time} =  Execute Command  stat -c %X ./textfiles
+    Should Be True  ${current_time} > ${last_access_time}
+    Should Be True  ${current_time} > ${last_modify_time}
     Remote Directory Should Exist With Subdirectories  ./textfiles
     [Teardown]  Execute Command  rm -rf ./textfiles
 

--- a/atest/put_directory.robot
+++ b/atest/put_directory.robot
@@ -81,6 +81,19 @@ Put Directory And Check For Proper Permissions
 	Check Folder Permissions    0755
 	[Teardown]  Execute Command  rm -rf ${CURDIR}${/}testdata${/}to_put
 
+Put Directory With SCP (transfer) And Preserve Time
+    Put Directory  ${LOCAL TEXTFILES}  .  recursive=True  scp=TRANSFER  scp_preserve_times=True
+    Remote Directory Should Exist With Subdirectories  ./textfiles
+     ${alo} =  Execute Command  stat ./textfiles
+#    [Teardown]  Execute Command  rm -rf ./textfiles
+
+Put Directory With SCP (all) And Preserve Time
+    [Tags]  pybot
+    Put Directory  ${LOCAL TEXTFILES}  .  recursive=True  scp=ALL  scp_preserve_times=True
+    ${alo} =  Execute Command  stat ./textfiles
+    Remote Directory Should Exist With Subdirectories  ./textfiles
+    [Teardown]  Execute Command  rm -rf ./textfiles
+
 *** Keywords ***
 Remove Local Empty Directory And Remote Files
     OS.Remove Directory  ${LOCAL TEXTFILES}${/}empty

--- a/atest/put_file.robot
+++ b/atest/put_file.robot
@@ -129,7 +129,7 @@ Put File And Check For Proper Permissions
 Put File With Scp (all) And Preserve Time
     SSH.File Should Not Exist  ${REMOTE TEST ROOT}/${TEST FILE NAME}
     Execute Command  mkdir ${REMOTE TEST ROOT NAME}
-    ${current_time} =  Get Current Date  result_format=epoch
+    ${current_time} =  Get Current Date  result_format=epoch  exclude_millis=True
     Put File  ${TEST FILE}  ${REMOTE TEST ROOT}/  scp=ALL  scp_preserve_times=True
     SSH.File Should Exist  ${REMOTE TEST ROOT}/${TEST FILE NAME}
     ${last_access_time} =  Execute Command  stat -c %X ${REMOTE TEST ROOT}/${TEST FILE NAME}
@@ -141,7 +141,7 @@ Put File With Scp (all) And Preserve Time
 Put File With SCP (transfer) And Preserve Time
     SSH.File Should Not Exist  ${REMOTE TEST ROOT}/${TEST FILE NAME}
     Execute Command  mkdir ${REMOTE TEST ROOT NAME}
-    ${current_time} =  Get Current Date  result_format=epoch
+    ${current_time} =  Get Current Date  result_format=epoch  exclude_millis=True
     Put File  ${TEST FILE}  ${REMOTE TEST ROOT}/  scp=TRANSFER  scp_preserve_times=True
     SSH.File Should Exist  ${REMOTE TEST ROOT}/${TEST FILE NAME}
     ${last_access_time} =  Execute Command  stat -c %X ${REMOTE TEST ROOT}/${TEST FILE NAME}

--- a/atest/put_file.robot
+++ b/atest/put_file.robot
@@ -5,6 +5,7 @@ Suite Setup     Login As Valid User
 Suite Teardown  Close All Connections
 Library         OperatingSystem  WITH NAME  OS
 Library         String
+Library         DateTime
 
 *** Test Cases ***
 Put File To Absolute Destination
@@ -128,17 +129,25 @@ Put File And Check For Proper Permissions
 Put File With Scp (all) And Preserve Time
     SSH.File Should Not Exist  ${REMOTE TEST ROOT}/${TEST FILE NAME}
     Execute Command  mkdir ${REMOTE TEST ROOT NAME}
+    ${current_time} =  Get Current Date  result_format=epoch
     Put File  ${TEST FILE}  ${REMOTE TEST ROOT}/  scp=ALL  scp_preserve_times=True
     SSH.File Should Exist  ${REMOTE TEST ROOT}/${TEST FILE NAME}
-    ${alo} =  Execute Command  stat ${REMOTE TEST ROOT}/${TEST FILE NAME}
+    ${last_access_time} =  Execute Command  stat -c %X ${REMOTE TEST ROOT}/${TEST FILE NAME}
+    ${last_modify_time} =  Execute Command  stat -c %X ${REMOTE TEST ROOT}/${TEST FILE NAME}
+    Should Be True  ${current_time} > ${last_access_time}
+    Should Be True  ${current_time} > ${last_modify_time}
     [Teardown]  Execute Command  rm -rf ${REMOTE TEST ROOT}
 
 Put File With SCP (transfer) And Preserve Time
     SSH.File Should Not Exist  ${REMOTE TEST ROOT}/${TEST FILE NAME}
     Execute Command  mkdir ${REMOTE TEST ROOT NAME}
+    ${current_time} =  Get Current Date  result_format=epoch
     Put File  ${TEST FILE}  ${REMOTE TEST ROOT}/  scp=TRANSFER  scp_preserve_times=True
     SSH.File Should Exist  ${REMOTE TEST ROOT}/${TEST FILE NAME}
-    ${alo} =  Execute Command  stat ${REMOTE TEST ROOT}/${TEST FILE NAME}
+    ${last_access_time} =  Execute Command  stat -c %X ${REMOTE TEST ROOT}/${TEST FILE NAME}
+    ${last_modify_time} =  Execute Command  stat -c %X ${REMOTE TEST ROOT}/${TEST FILE NAME}
+    Should Be True  ${current_time} > ${last_access_time}
+    Should Be True  ${current_time} > ${last_modify_time}
     [Teardown]  Execute Command  rm -rf ${REMOTE TEST ROOT}
 
 *** Keywords ***

--- a/atest/put_file.robot
+++ b/atest/put_file.robot
@@ -125,6 +125,22 @@ Put File And Check For Proper Permissions
 	Check File Permissions    0755    ${REMOTE_TEST_ROOT}${/}${TEST FILE NAME}
 	[Teardown]  Execute Command  rm -rf ${REMOTE TEST ROOT}
 
+Put File With Scp (all) And Preserve Time
+    SSH.File Should Not Exist  ${REMOTE TEST ROOT}/${TEST FILE NAME}
+    Execute Command  mkdir ${REMOTE TEST ROOT NAME}
+    Put File  ${TEST FILE}  ${REMOTE TEST ROOT}/  scp=ALL  scp_preserve_times=True
+    SSH.File Should Exist  ${REMOTE TEST ROOT}/${TEST FILE NAME}
+    ${alo} =  Execute Command  stat ${REMOTE TEST ROOT}/${TEST FILE NAME}
+    [Teardown]  Execute Command  rm -rf ${REMOTE TEST ROOT}
+
+Put File With SCP (transfer) And Preserve Time
+    SSH.File Should Not Exist  ${REMOTE TEST ROOT}/${TEST FILE NAME}
+    Execute Command  mkdir ${REMOTE TEST ROOT NAME}
+    Put File  ${TEST FILE}  ${REMOTE TEST ROOT}/  scp=TRANSFER  scp_preserve_times=True
+    SSH.File Should Exist  ${REMOTE TEST ROOT}/${TEST FILE NAME}
+    ${alo} =  Execute Command  stat ${REMOTE TEST ROOT}/${TEST FILE NAME}
+    [Teardown]  Execute Command  rm -rf ${REMOTE TEST ROOT}
+
 *** Keywords ***
 Change User And Overwrite File
     Open Connection  ${HOST}  prompt=${PROMPT}

--- a/src/SSHLibrary/javaclient.py
+++ b/src/SSHLibrary/javaclient.py
@@ -176,7 +176,7 @@ class SFTPClient(AbstractSFTPClient):
     def _close_remote_file(self, remote_file):
         self._client.closeFile(remote_file)
 
-    def _get_file(self, remote_path, local_path):
+    def _get_file(self, remote_path, local_path, scp_preserve_times):
         local_file = FileOutputStream(local_path)
         remote_file_size = self._client.stat(remote_path).size
         remote_file = self._client.openFileRO(remote_path)
@@ -229,11 +229,11 @@ class SCPTransferClient(SFTPClient):
         self._scp_client = JavaSCPClient(ssh_client)
         super(SCPTransferClient, self).__init__(ssh_client, encoding)
 
-    def _put_file(self, source, destination, mode, newline, path_separator):
+    def _put_file(self, source, destination, mode, newline, path_separator, scp_preserve_times):
         self._create_remote_file(destination, mode)
         self._scp_client.put(source, destination.rsplit(path_separator, 1)[0])
 
-    def _get_file(self, remote_path, local_path):
+    def _get_file(self, remote_path, local_path, scp_preserve_times):
         self._scp_client.get(remote_path, local_path.rsplit(os.sep, 1)[0])
 
 

--- a/src/SSHLibrary/library.py
+++ b/src/SSHLibrary/library.py
@@ -384,6 +384,14 @@ class SSHLibrary(object):
 
      SCP transfer was introduced in SSHLibrary 3.3.0.
 
+    == Preserving original times ==
+    SCP allows some configuration when transferring files and directories. One of this configuration is whether to
+    preserve the original modify time and access time of transferred files and directories. This is done using the
+    ``scp_preserve_times`` argument. This argument works only when ``scp`` argument is set to ``TRANSFER`` or ``ALL``.
+    Also, when running with Jython ``scp_preserve_times`` won't work due to current current Trilead implementation.
+
+    ``scp_preserve_times`` was introduced in SSHLibrary 3.6.0.
+
     = Aliases =
     SSHLibrary allows the use of an alias when opening a new connection using the parameter ``alias``.
 

--- a/src/SSHLibrary/library.py
+++ b/src/SSHLibrary/library.py
@@ -1533,7 +1533,7 @@ class SSHLibrary(object):
         output = ansi_escape.sub('', output)
         return ("%r" % output)[1:-1].encode().decode('unicode-escape')
 
-    def get_file(self, source, destination='.', scp='OFF'):
+    def get_file(self, source, destination='.', scp='OFF', scp_preserve_times=False):
         """Downloads file(s) from the remote machine to the local machine.
 
         ``source`` is a path on the remote machine. Both absolute paths and
@@ -1548,6 +1548,9 @@ class SSHLibrary(object):
 
         ``scp`` enables the use of scp (secure copy protocol) for
         the file transfer. See `Transfer files with SCP` for more details.
+
+        ``scp_preserve_times`` preserve modification time and access time
+        of transferred files and directories.
 
         Examples:
         | `Get File` | /var/log/auth.log | /tmp/                      |
@@ -1581,13 +1584,13 @@ class SSHLibrary(object):
 
         See also `Get Directory`.
 
-        ``scp`` is new in SSHLibrary 3.3.0.
+        ``scp_preserve_times`` is new in SSHLibrary 3.6.0.
         """
         return self._run_command(self.current.get_file, source,
-                                 destination, scp)
+                                 destination, scp, scp_preserve_times)
 
     def get_directory(self, source, destination='.', recursive=False,
-                      scp='OFF'):
+                      scp='OFF', scp_preserve_times=False):
         """Downloads a directory, including its content, from the remote machine to the local machine.
 
         ``source`` is a path on the remote machine. Both absolute paths and
@@ -1603,6 +1606,9 @@ class SSHLibrary(object):
 
         ``scp`` enables the use of scp (secure copy protocol) for
         the file transfer. See `Transfer files with SCP` for more details.
+
+        ``scp_preserve_times`` preserve modification time and access time
+        of transferred files and directories.
 
         Examples:
         | `Get Directory` | /var/logs      | /tmp                |
@@ -1627,13 +1633,13 @@ class SSHLibrary(object):
 
         See also `Get File`.
 
-        ``scp`` is new in SSHLibrary 3.3.0.
+        ``scp_preserve_times`` is new in SSHLibrary 3.6.0.
         """
         return self._run_command(self.current.get_directory, source,
-                                 destination, is_truthy(recursive), scp)
+                                 destination, is_truthy(recursive), scp, scp_preserve_times)
 
     def put_file(self, source, destination='.', mode='0744', newline='',
-                 scp='OFF'):
+                 scp='OFF', scp_preserve_times=False):
         """Uploads file(s) from the local machine to the remote machine.
 
         ``source`` is the path on the local machine. Both absolute paths and
@@ -1657,6 +1663,9 @@ class SSHLibrary(object):
 
         ``scp`` enables the use of scp (secure copy protocol) for
         the file transfer. See `Transfer files with SCP` for more details.
+
+        ``scp_preserve_times`` preserve modification time and access time
+        of transferred files and directories.
 
         Examples:
         | `Put File` | /path/to/*.txt          |
@@ -1686,13 +1695,13 @@ class SSHLibrary(object):
 
         See also `Put Directory`.
 
-        ``scp`` is new in SSHLibrary 3.3.0.
+        ``scp_preserve_times`` is new in SSHLibrary 3.6.0.
         """
         return self._run_command(self.current.put_file, source,
-                                 destination, mode, newline, scp)
+                                 destination, mode, newline, scp, scp_preserve_times)
 
     def put_directory(self, source, destination='.', mode='0744', newline='',
-                      recursive=False, scp='OFF'):
+                      recursive=False, scp='OFF', scp_preserve_times=False):
         """Uploads a directory, including its content, from the local machine to the remote machine.
 
         ``source`` is the path on the local machine. Both absolute paths and
@@ -1717,6 +1726,9 @@ class SSHLibrary(object):
         ``scp`` enables the use of scp (secure copy protocol) for
         the file transfer. See `Transfer files with SCP` for more details.
 
+        ``scp_preserve_times`` preserve modification time and access time
+        of transferred files and directories.
+
         Examples:
         | `Put Directory` | /var/logs | /tmp               |
         | `Put Directory` | /var/logs | /tmp/non/existing  |
@@ -1739,11 +1751,11 @@ class SSHLibrary(object):
 
         See also `Put File`.
 
-        ``scp`` is new in SSHLibrary 3.3.0.
+        ``scp_preserve_times`` is new in SSHLibrary 3.6.0.
         """
         return self._run_command(self.current.put_directory, source,
                                  destination, mode, newline,
-                                 is_truthy(recursive), scp)
+                                 is_truthy(recursive), scp, scp_preserve_times)
 
     def _run_command(self, command, *args):
         try:

--- a/src/SSHLibrary/library.py
+++ b/src/SSHLibrary/library.py
@@ -388,7 +388,9 @@ class SSHLibrary(object):
     SCP allows some configuration when transferring files and directories. One of this configuration is whether to
     preserve the original modify time and access time of transferred files and directories. This is done using the
     ``scp_preserve_times`` argument. This argument works only when ``scp`` argument is set to ``TRANSFER`` or ``ALL``.
-    Also, when running with Jython ``scp_preserve_times`` won't work due to current current Trilead implementation.
+    When moving directory with ``scp`` set to ``TRANSFER`` and ``scp_preserve_times`` is enabled only the files inside
+    the director will keep their original timestamps. Also, when running with Jython ``scp_preserve_times`` won't work
+    due to current current Trilead implementation.
 
     ``scp_preserve_times`` was introduced in SSHLibrary 3.6.0.
 

--- a/src/SSHLibrary/pythonclient.py
+++ b/src/SSHLibrary/pythonclient.py
@@ -266,7 +266,7 @@ class SFTPClient(AbstractSFTPClient):
     def _close_remote_file(self, remote_file):
         remote_file.close()
 
-    def _get_file(self, remote_path, local_path):
+    def _get_file(self, remote_path, local_path, scp_preserve_times):
         remote_path = remote_path.encode(self._encoding)
         self._client.get(remote_path, local_path)
 
@@ -288,17 +288,17 @@ class SCPClient(object):
     def __init__(self, ssh_client):
         self._scp_client = scp.SCPClient(ssh_client.get_transport())
 
-    def put_file(self, source, destination, *args):
-        self._scp_client.put(source, destination)
+    def put_file(self, source, destination, scp_preserve_times, *args):
+        self._scp_client.put(source, destination, preserve_times=is_truthy(scp_preserve_times))
 
-    def get_file(self, source, destination, *args):
-        self._scp_client.get(source, destination)
+    def get_file(self, source, destination, scp_preserve_times, *args):
+        self._scp_client.get(source, destination, preserve_times=is_truthy(scp_preserve_times))
 
-    def put_directory(self, source, destination, *args):
-        self._scp_client.put(source, destination, True)
+    def put_directory(self, source, destination, scp_preserve_times, *args):
+        self._scp_client.put(source, destination, True, preserve_times=is_truthy(scp_preserve_times))
 
-    def get_directory(self, source, destination, *args):
-        self._scp_client.get(source, destination, True)
+    def get_directory(self, source, destination, scp_preserve_times, *args):
+        self._scp_client.get(source, destination, True, preserve_times=is_truthy(scp_preserve_times))
 
 
 class SCPTransferClient(SFTPClient):
@@ -307,12 +307,12 @@ class SCPTransferClient(SFTPClient):
         self._scp_client = scp.SCPClient(ssh_client.get_transport())
         super(SCPTransferClient, self).__init__(ssh_client, encoding)
 
-    def _put_file(self, source, destination, mode, newline, path_separator):
+    def _put_file(self, source, destination, mode, newline, path_separator, scp_preserve_times=False):
         self._create_remote_file(destination, mode)
-        self._scp_client.put(source, destination)
+        self._scp_client.put(source, destination, preserve_times=is_truthy(scp_preserve_times))
 
-    def _get_file(self, remote_path, local_path):
-        self._scp_client.get(remote_path, local_path)
+    def _get_file(self, remote_path, local_path, scp_preserve_times=False):
+        self._scp_client.get(remote_path, local_path, preserve_times=is_truthy(scp_preserve_times))
 
 
 class RemoteCommand(AbstractCommand):


### PR DESCRIPTION
This PR aims to add new parameter `-p` when transferring files using `SCP`. This parameter will preserve original access time and modification time of the files that are transferred.