### PR TITLE
Extend jump host functionality to password logins

### DIFF
--- a/src/SSHLibrary/abstractclient.py
+++ b/src/SSHLibrary/abstractclient.py
@@ -160,7 +160,7 @@ class AbstractSSHClient(object):
             pass
 
     def login(self, username, password, allow_agent=False, look_for_keys=False, delay=None, proxy_cmd=None,
-              read_config_host=False):
+              read_config_host=False, jumphost_connection=None):
         """Logs into the remote host using password authentication.
 
         This method reads the output from the remote host after logging in,
@@ -187,6 +187,10 @@ class AbstractSSHClient(object):
 
         :param read_config_host: reads or ignores host entries from ``~/.ssh/config`` file.
 
+        :param PythonSSHClient jumphost_connection : An instance of
+            PythonSSHClient that will be used as an intermediary jump-host
+            for the SSH connection being attempted.
+
         :raises SSHClientException: If logging in failed.
 
         :returns: The read output from the server.
@@ -194,7 +198,7 @@ class AbstractSSHClient(object):
         username = self._encode(username)
         password = self._encode(password)
         try:
-            self._login(username, password, allow_agent, look_for_keys, proxy_cmd, read_config_host)
+            self._login(username, password, allow_agent, look_for_keys, proxy_cmd, read_config_host, jumphost_connection)
         except SSHClientException:
             self.client.close()
             raise SSHClientException("Authentication failed for user '%s'."
@@ -211,7 +215,7 @@ class AbstractSSHClient(object):
     def _decode(self, bytes):
         return bytes.decode(self.config.encoding)
 
-    def _login(self, username, password, allow_agent, look_for_keys, proxy_cmd, read_config_host):
+    def _login(self, username, password, allow_agent, look_for_keys, proxy_cmd, read_config_host, jumphost_connection):
         raise NotImplementedError
 
     def _read_login_output(self, delay):

--- a/src/SSHLibrary/pythonclient.py
+++ b/src/SSHLibrary/pythonclient.py
@@ -116,18 +116,19 @@ class PythonSSHClient(AbstractSSHClient):
                                jumphost_connection=None, read_config_host=False):
         if read_config_host:
             self.config.host = self._read_ssh_config_host(self.config.host)
-        sock_tunnel=None
-        if proxy_cmd and not jumphost_connection:
+        sock_tunnel = None
+
+        if proxy_cmd and jumphost_connection:
+            raise ValueError("`proxy_cmd` and `jumphost_connection` are mutually exclusive SSH features.")
+        elif proxy_cmd:
             sock_tunnel = paramiko.ProxyCommand(proxy_cmd)
-        elif jumphost_connection and not proxy_cmd:
+        elif jumphost_connection:
             dest_addr = (self.config.host, self.config.port)
             jump_addr = (jumphost_connection.config.host, jumphost_connection.config.port)
             jumphost_transport = jumphost_connection.client.get_transport()
             if not jumphost_transport:
                 raise RuntimeError("Could not get transport for {}:{}. Have you logged in?".format(*jump_addr))
             sock_tunnel = jumphost_transport.open_channel("direct-tcpip", dest_addr, jump_addr)
-        elif proxy_cmd and jumphost_connection:
-            raise ValueError("`proxy_cmd` and `jumphost_connection` are mutually exclusive SSH features.")
 
         try:
             self.client.connect(self.config.host, self.config.port, username,

--- a/src/SSHLibrary/pythonclient.py
+++ b/src/SSHLibrary/pythonclient.py
@@ -60,8 +60,10 @@ def _custom_log(self, level, msg, *args):
         msg = escape(msg)
     return self._orig_log(level, msg, *args)
 
+
 paramiko.sftp_client.SFTPClient._orig_log = paramiko.sftp_client.SFTPClient._log
 paramiko.sftp_client.SFTPClient._log = _custom_log
+
 
 class PythonSSHClient(AbstractSSHClient):
     tunnel = None
@@ -127,6 +129,7 @@ class PythonSSHClient(AbstractSSHClient):
                 sock_tunnel = jumphost_transport.open_channel("direct-tcpip", dest_addr, jump_addr)
             elif proxy_cmd and jumphost_connection:
                 raise ValueError("`proxy_cmd` and `jumphost_connection` are mutually exclusive SSH features.")
+
             self.client.connect(self.config.host, self.config.port, username,
                                 password, key_filename=key_file,
                                 allow_agent=allow_agent,
@@ -334,7 +337,7 @@ class RemoteCommand(AbstractCommand):
         while self._shell_open():
             self._flush_stdout_and_stderr(stderr_filebuffer, stderrs, stdout_filebuffer, stdouts, timeout,
                                           output_during_execution, output_if_timeout)
-            time.sleep(0.01) # lets not be so busy
+            time.sleep(0.01)  # lets not be so busy
         stdout = (b''.join(stdouts) + stdout_filebuffer.read()).decode(self._encoding)
         stderr = (b''.join(stderrs) + stderr_filebuffer.read()).decode(self._encoding)
         return stderr, stdout
@@ -369,9 +372,9 @@ class RemoteCommand(AbstractCommand):
 
     def _shell_open(self):
         return not (self._shell.closed or
-                self._shell.eof_received or
-                self._shell.eof_sent or
-                not self._shell.active)
+                    self._shell.eof_received or
+                    self._shell.eof_sent or
+                    not self._shell.active)
 
     def _execute(self):
         self._shell.exec_command(self._command)

--- a/src/SSHLibrary/pythonclient.py
+++ b/src/SSHLibrary/pythonclient.py
@@ -116,20 +116,20 @@ class PythonSSHClient(AbstractSSHClient):
                                jumphost_connection=None, read_config_host=False):
         if read_config_host:
             self.config.host = self._read_ssh_config_host(self.config.host)
-        try:
-            sock_tunnel=None
-            if proxy_cmd and not jumphost_connection:
-                sock_tunnel = paramiko.ProxyCommand(proxy_cmd)
-            elif jumphost_connection and not proxy_cmd:
-                dest_addr = (self.config.host, self.config.port)
-                jump_addr = (jumphost_connection.config.host, jumphost_connection.config.port)
-                jumphost_transport = jumphost_connection.client.get_transport()
-                if not jumphost_transport:
-                    raise RuntimeError("Could not get transport for {}:{}. Have you logged in?".format(*jump_addr))
-                sock_tunnel = jumphost_transport.open_channel("direct-tcpip", dest_addr, jump_addr)
-            elif proxy_cmd and jumphost_connection:
-                raise ValueError("`proxy_cmd` and `jumphost_connection` are mutually exclusive SSH features.")
+        sock_tunnel=None
+        if proxy_cmd and not jumphost_connection:
+            sock_tunnel = paramiko.ProxyCommand(proxy_cmd)
+        elif jumphost_connection and not proxy_cmd:
+            dest_addr = (self.config.host, self.config.port)
+            jump_addr = (jumphost_connection.config.host, jumphost_connection.config.port)
+            jumphost_transport = jumphost_connection.client.get_transport()
+            if not jumphost_transport:
+                raise RuntimeError("Could not get transport for {}:{}. Have you logged in?".format(*jump_addr))
+            sock_tunnel = jumphost_transport.open_channel("direct-tcpip", dest_addr, jump_addr)
+        elif proxy_cmd and jumphost_connection:
+            raise ValueError("`proxy_cmd` and `jumphost_connection` are mutually exclusive SSH features.")
 
+        try:
             self.client.connect(self.config.host, self.config.port, username,
                                 password, key_filename=key_file,
                                 allow_agent=allow_agent,

--- a/src/SSHLibrary/pythonclient.py
+++ b/src/SSHLibrary/pythonclient.py
@@ -90,26 +90,25 @@ class PythonSSHClient(AbstractSSHClient):
                read_config_host=False):
         if read_config_host:
             self.config.host = self._read_ssh_config_host(self.config.host)
+
+        if proxy_cmd:
+            proxy_cmd = paramiko.ProxyCommand(proxy_cmd)
+
         try:
-            if proxy_cmd:
-                proxy_cmd = paramiko.ProxyCommand(proxy_cmd)
-            try:
-                self.client.connect(self.config.host, self.config.port, username,
-                                    password, look_for_keys=look_for_keys,
-                                    allow_agent=allow_agent,
-                                    timeout=float(self.config.timeout), sock=proxy_cmd)
-            except paramiko.AuthenticationException:
-                try:
-                    transport = self.client.get_transport()
-                    try:
-                        transport.auth_none(username)
-                    except:
-                        pass
-                    transport.auth_password(username,password)
-                except:
-                    raise SSHClientException
+            self.client.connect(self.config.host, self.config.port, username,
+                                password, look_for_keys=look_for_keys,
+                                allow_agent=allow_agent,
+                                timeout=float(self.config.timeout), sock=proxy_cmd)
         except paramiko.AuthenticationException:
-            raise SSHClientException
+            try:
+                transport = self.client.get_transport()
+                try:
+                    transport.auth_none(username)
+                except:
+                    pass
+                transport.auth_password(username,password)
+            except:
+                raise SSHClientException
 
     def _login_with_public_key(self, username, key_file, password, allow_agent, look_for_keys, proxy_cmd=None,
                                jumphost_connection=None, read_config_host=False):


### PR DESCRIPTION
Currently jump host functionality only works with public key logins.

Instead of making the login parts more convoluted I first cleaned it up a bit. It's easier to see the point of those changes with whitespace ignored with: `git diff -w `

For example the "limit try-except to meaningful section of code" is just:
```--- a/src/SSHLibrary/pythonclient.py
+++ b/src/SSHLibrary/pythonclient.py
@@ -116,7 +116,6 @@ class PythonSSHClient(AbstractSSHClient):
                                jumphost_connection=None, read_config_host=False):
         if read_config_host:
             self.config.host = self._read_ssh_config_host(self.config.host)
-        try:
         sock_tunnel=None
         if proxy_cmd and not jumphost_connection:
             sock_tunnel = paramiko.ProxyCommand(proxy_cmd)
@@ -130,6 +129,7 @@ class PythonSSHClient(AbstractSSHClient):
         elif proxy_cmd and jumphost_connection:
             raise ValueError("`proxy_cmd` and `jumphost_connection` are mutually exclusive SSH features.")
 
+        try:
             self.client.connect(self.config.host, self.config.port, username,
                                 password, key_filename=key_file,
                                 allow_agent=allow_agent,
```