### PR TITLE
Support logins without authentication

### DIFF
--- a/src/SSHLibrary/abstractclient.py
+++ b/src/SSHLibrary/abstractclient.py
@@ -192,7 +192,8 @@ class AbstractSSHClient(object):
         :returns: The read output from the server.
         """
         username = self._encode(username)
-        password = self._encode(password)
+        if password != None:
+            password = self._encode(password)
         try:
             self._login(username, password, allow_agent, look_for_keys, proxy_cmd, read_config_host)
         except SSHClientException:


### PR DESCRIPTION
With password=None, paramiko skips authentication and raises
SSHException. Then only call auth_none() without auth_password()
to log in. Separated from the normal call path as a different
exception needs to be catched.