### PR TITLE
Define own constants rather than relying on RF

### DIFF
--- a/src/SSHLibrary/pythonforward.py
+++ b/src/SSHLibrary/pythonforward.py
@@ -1,9 +1,16 @@
+import os
 import select
 import socket
+import sys
 import threading
-from robot.utils import platform
 from .logger import logger
-if platform.PY2 and platform.WINDOWS:
+
+
+PY2 = sys.version_info[0] == 2
+WINDOWS = os.sep != "/"
+
+
+if PY2 and WINDOWS:
     import win_inet_pton
 try:
     import SocketServer


### PR DESCRIPTION
Fix #401.

These constants are simple enough to decouple and define locally rather than placing a constraint on Robot Framework.

(Ideally Python 2 can be dropped soon and both can be removed :)
